### PR TITLE
Add option to show document id if total count in cluster is 1

### DIFF
--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/Cluster.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/Cluster.java
@@ -16,22 +16,30 @@ public class Cluster {
 	private int size;
 	private GeoPoint center;
     private String clusterGeohash;
+    private String docId;
 	private BoundingBox bounds;
 
     /**
      * @param clusterGeohash - geohash of the cluster. Must be a prefix of geoItem.geoPoint().geoHash()
      */
+    
 	public Cluster(GeoPoint point, String clusterGeohash) {
-        this(1, point, clusterGeohash, new BoundingBox(point));
+        this(1, point, clusterGeohash, new String(), new BoundingBox(point));
 
 	}
 
-	public Cluster(int size, GeoPoint center, String clusterGeohash, BoundingBox bounds) {
+	public Cluster(GeoPoint point, String clusterGeohash, String docId) {
+        this(1, point, clusterGeohash, docId, new BoundingBox(point));
+
+	}
+
+	public Cluster(int size, GeoPoint center, String clusterGeohash, String docId, BoundingBox bounds) {
         Preconditions.checkArgument(center.getGeohash().startsWith(clusterGeohash));
 
 		this.size = size;
 		this.center = center;
         this.clusterGeohash = clusterGeohash;
+        this.docId = docId;
 		this.bounds = bounds;
 	}
 
@@ -48,7 +56,7 @@ public class Cluster {
 
 		GeoPoint center = mean(this.center, this.size(), that.center(), that.size());
 		return new Cluster(this.size + that.size(),
-                center, this.clusterGeohash, this.bounds.extend(that.bounds()));
+                center, this.clusterGeohash, new String(), this.bounds.extend(that.bounds()));
 	}
 
 	private static GeoPoint mean(GeoPoint left, int leftWeight, GeoPoint right, int rightWeight) {
@@ -73,14 +81,19 @@ public class Cluster {
         return clusterGeohash;
     }
 
+    public String docId() {
+        return docId;
+    }
+
     public static Cluster readFrom(StreamInput in) throws IOException {
 		int size = in.readVInt();
 		GeoPoint center = GeoPoints.readFrom(in);
+        String docId = in.readString();
         String clusterGeohash = in.readString();
 		BoundingBox bounds = size > 1
 			? BoundingBox.readFrom(in)
 			: new BoundingBox(center, center);
-		return new Cluster(size, center, clusterGeohash, bounds);
+		return new Cluster(size, center, clusterGeohash, docId, bounds);
 	}
 
 	public void writeTo(StreamOutput out) throws IOException {
@@ -88,8 +101,11 @@ public class Cluster {
 		GeoPoints.writeTo(center, out);
         out.writeString(clusterGeohash);
 		if (size > 1) {
+            out.writeString(new String());
 			bounds.writeTo(out);
-		}
+		} else {
+            out.writeString(docId);
+        }
 	}
 
 	@Override

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/ClusterBuilder.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/ClusterBuilder.java
@@ -2,6 +2,7 @@ package nl.trifork.elasticsearch.facet.geohash;
 
 import java.util.Map;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.collect.Maps;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -13,23 +14,29 @@ public class ClusterBuilder {
     private static final int GEOHASH_MAX_LENGTH = 12;
 
 	private final double factor;
+    private final boolean showDocuments;
 	private final int prefixLength;
 	private final Map<String, Cluster> clusters = Maps.newHashMap();
 
-	public ClusterBuilder(double factor) {
+	public ClusterBuilder(double factor, boolean showDocuments) {
 		this.factor = factor;
+        this.showDocuments = showDocuments;
         this.prefixLength = GEOHASH_MAX_LENGTH - (int) Math.round(factor * GEOHASH_MAX_LENGTH);
 	}
 
-	public ClusterBuilder add(GeoPoint point) {
+    public ClusterBuilder add(String docId, GeoPoint point) {
         String prefix = point.geohash().substring(0, prefixLength);
         if (clusters.containsKey(prefix)) {
             clusters.get(prefix).add(point);
         }
         else {
-            clusters.put(prefix, new Cluster(point, prefix));
+            clusters.put(prefix, new Cluster(point, prefix, docId));
         }
 		return this;
+    }
+
+	public ClusterBuilder add(GeoPoint point) {
+        return add(new String(), point);
 	}
 
 	public ImmutableList<Cluster> build() {

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeohashFacetExecutor.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeohashFacetExecutor.java
@@ -2,24 +2,35 @@ package nl.trifork.elasticsearch.facet.geohash;
 
 import java.io.IOException;
 
+import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.index.AtomicReaderContext;
 import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
+import org.elasticsearch.index.fielddata.BytesValues;
+import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.search.facet.FacetExecutor;
 import org.elasticsearch.search.facet.InternalFacet;
+
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.index.mapper.Uid;
 
 public class GeohashFacetExecutor extends FacetExecutor {
 
 	private final IndexGeoPointFieldData<?> indexFieldData;
+	private final IndexFieldData<?> idIndexFieldData;
 	private final double factor;
     private final boolean showGeohashCell;
+    private final boolean showDocuments;
 	private final ClusterBuilder builder;
-
-	public GeohashFacetExecutor(IndexGeoPointFieldData<?> indexFieldData, double factor, boolean showGeohashCell) {
+	
+	public GeohashFacetExecutor(IndexGeoPointFieldData<?> indexFieldData, IndexFieldData<?> idIndexFieldData, 
+			                    double factor, boolean showGeohashCell, boolean showDocuments) {
 		this.indexFieldData = indexFieldData;
+		this.idIndexFieldData = idIndexFieldData;
 		this.factor = factor;
         this.showGeohashCell = showGeohashCell;
-		this.builder = new ClusterBuilder(factor);
+        this.showDocuments = showDocuments;
+		this.builder = new ClusterBuilder(factor, showDocuments);
 	}
 
 	@Override
@@ -29,23 +40,41 @@ public class GeohashFacetExecutor extends FacetExecutor {
 
 	@Override
 	public InternalFacet buildFacet(String facetName) {
-		return new InternalGeohashFacet(facetName, factor, showGeohashCell, builder.build());
+		return new InternalGeohashFacet(facetName, factor, showGeohashCell, showDocuments, builder.build());
 	}
 
 	private class Collector extends FacetExecutor.Collector {
 
+		private BytesValues ids;
 		private GeoPointValues values;
 
 		@Override
 		public void setNextReader(AtomicReaderContext context) throws IOException {
+			ids = idIndexFieldData.load(context).getBytesValues(false);
+			//ordinals = ids.ordinals();
 			values = indexFieldData.load(context).getGeoPointValues();
 		}
 
 		@Override
 		public void collect(int docId) throws IOException {
+            final int length_ = ids.setDocument(docId);
             final int length = values.setDocument(docId);
+            
+            String _id;
+            if (length_ > 0) {
+            	_id = Uid.idFromUid(ids.nextValue().utf8ToString());
+            } else {
+            	_id = new String();
+            }
+            
             for (int i = 0; i < length; i++) {
-                builder.add(GeoPoints.copy(values.nextValue())); // nextValue() may recycle GeoPoint instances!
+            	GeoPoint gp = GeoPoints.copy(values.nextValue()); // nextValue() may recycle GeoPoint instances!
+            	
+                if(showDocuments) {
+                    builder.add(_id, gp);
+                } else {
+                    builder.add(gp);
+                }
             }
 		}
 

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
@@ -35,16 +35,18 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 
 	private double factor;
     private boolean showGeohashCell;
+    private boolean showDocuments;
 	private List<Cluster> entries;
 
 	InternalGeohashFacet() {
 
 	}
 
-	public InternalGeohashFacet(String name, double factor, boolean showGeohashCell, List<Cluster> entries) {
+	public InternalGeohashFacet(String name, double factor, boolean showGeohashCell, boolean showDocuments, List<Cluster> entries) {
 		super(name);
 		this.factor = factor;
-        this.showGeohashCell =showGeohashCell;
+        this.showGeohashCell = showGeohashCell;
+        this.showDocuments = showDocuments;
 		this.entries = entries;
 	}
 
@@ -72,7 +74,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 	public Facet reduce(ReduceContext context) {
 		ClusterReducer reducer = new ClusterReducer();
 		List<Cluster> reduced = reducer.reduce(flatMap(context.facets()));
-		return new InternalGeohashFacet(getName(), factor, showGeohashCell, reduced);
+		return new InternalGeohashFacet(getName(), factor, showGeohashCell, showDocuments, reduced);
 	}
 
 	private List<Cluster> flatMap(Iterable<Facet> facets) {
@@ -121,6 +123,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 		final XContentBuilderString LAT = new XContentBuilderString("lat");
 		final XContentBuilderString LON = new XContentBuilderString("lon");
 		final XContentBuilderString GEOHASH_CELL = new XContentBuilderString("geohash_cell");
+        final XContentBuilderString DOC_ID = new XContentBuilderString("doc_id");
 	}
 
 	@Override
@@ -144,7 +147,9 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 		if (cluster.size() > 1) {
 			toXContent(cluster.bounds().topLeft(), Fields.TOP_LEFT, builder);
 			toXContent(cluster.bounds().bottomRight(), Fields.BOTTOM_RIGHT, builder);
-		}
+		} else if (showDocuments) {
+			builder.field(Fields.DOC_ID, cluster.docId());
+        }
         if (showGeohashCell) {
             addGeohashCell(cluster, builder);
         }


### PR DESCRIPTION
When 1 element is returned in faceting, return it's `_id` property too. That way we can localize it via the GET api and return additional info for it on pins, for example.
