### PR TITLE
Factor in precision bits renamed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Result:
             "_type" : "geohash",
             "precision_bits" : 6,
             "factor" : 0.9,
+            "clusters_total": 2,
             "clusters" : [ {
                 "total" : 8,
                 "center" : {
@@ -279,6 +280,7 @@ Result:
             "_type" : "geohash",
             "precision_bits" : 6,
             "factor" : 0.9,
+            "clusters_total": 2,
             "clusters" : [ {
                 "total" : 8,
                 "center" : {

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Parameters
         	of the level of clustering.</td>
         </tr>
 		<tr>
+            <th>precision_bits</th>
+        	<td>Instead of `factor`, you can also provide the used geohash bits directly
+            (otherwise the `precision_bits` gets internaly computed from the `factor` parameter).
+            Starting from version 0.0.14, the maximal precision is 60 bits.
+            If you supply `factor` and `precision_bits`, only `precision_bits` are used.</td>
+        </tr>
+		<tr>
             <th>show_geohash_cell</th>
         	<td>Boolean. If true, for each cluster included in the reply the coordinates
         	of the corresponding geohash cell are provided (top left and bottom right corner.
@@ -198,6 +205,7 @@ Result:
     "facets" : {
         "places" : {
             "_type" : "geohash",
+            "precision_bits" : 6,
             "factor" : 0.9,
             "clusters" : [ {
                 "total" : 8,
@@ -242,7 +250,7 @@ Query with show_geohash_cell enabled:
         "places" : {
             "geohash" : {
                 "field" : "location",
-                "factor" : 0.9,
+                "precision_bits" : 6,
                 "show_geohash_cell" : true
             }
         }
@@ -269,6 +277,7 @@ Result:
     "facets" : {
         "places" : {
             "_type" : "geohash",
+            "precision_bits" : 6,
             "factor" : 0.9,
             "clusters" : [ {
                 "total" : 8,
@@ -333,9 +342,9 @@ public class Example {
 
     public static void main(String[] args) {
     
-        GeoFacetBuilder facetBuilder = new GeoFacetBuilder("monuments").
-                field("location").
-                factor(0.9)
+        GeoFacetBuilder facetBuilder = new GeoFacetBuilder("monuments")
+                .field("location")
+                .factor(0.9)
                 .showGeohashCell(false)
                 .showDocId(true);
 
@@ -367,73 +376,74 @@ The table below shows the size of the cells defined by various values of the `fa
 <table>
     <thead>
 		<tr>
-			<th>Factor</th>
+			<th>Factor (rounded)</th>
+            <th>Precision bits</th>
 			<th>Latitude delta (degrees)</th>
 			<th>Longitude delta (degrees)</th>
 		</tr>
 	</thead>
 	<tbody>
-<tr><td>1</td><td>180</td><td>360</td></tr>
-<tr><td>0.98</td><td>180</td><td>180</td></tr>
-<tr><td>0.97</td><td>90</td><td>180</td></tr>
-<tr><td>0.95</td><td>90</td><td>90</td></tr>
-<tr><td>0.93</td><td>45</td><td>90</td></tr>
-<tr><td>0.92</td><td>45</td><td>45</td></tr>
-<tr><td>0.9</td><td>22.5</td><td>45</td></tr>
-<tr><td>0.88</td><td>22.5</td><td>22.5</td></tr>
-<tr><td>0.87</td><td>11.25</td><td>22.5</td></tr>
-<tr><td>0.85</td><td>11.25</td><td>11.25</td></tr>
-<tr><td>0.83</td><td>5.625</td><td>11.25</td></tr>
-<tr><td>0.82</td><td>5.625</td><td>5.625</td></tr>
-<tr><td>0.8</td><td>2.8125</td><td>5.625</td></tr>
-<tr><td>0.78</td><td>2.8125</td><td>2.8125</td></tr>
-<tr><td>0.77</td><td>1.40625</td><td>2.8125</td></tr>
-<tr><td>0.75</td><td>1.40625</td><td>1.40625</td></tr>
-<tr><td>0.73</td><td>0.703125</td><td>1.40625</td></tr>
-<tr><td>0.72</td><td>0.703125</td><td>0.703125</td></tr>
-<tr><td>0.7</td><td>0.3515625</td><td>0.703125</td></tr>
-<tr><td>0.68</td><td>0.3515625</td><td>0.3515625</td></tr>
-<tr><td>0.67</td><td>0.17578125</td><td>0.3515625</td></tr>
-<tr><td>0.65</td><td>0.17578125</td><td>0.17578125</td></tr>
-<tr><td>0.63</td><td>0.087890625</td><td>0.17578125</td></tr>
-<tr><td>0.62</td><td>0.087890625</td><td>0.087890625</td></tr>
-<tr><td>0.6</td><td>0.0439453125</td><td>0.087890625</td></tr>
-<tr><td>0.58</td><td>0.0439453125</td><td>0.0439453125</td></tr>
-<tr><td>0.57</td><td>0.02197265625</td><td>0.0439453125</td></tr>
-<tr><td>0.55</td><td>0.02197265625</td><td>0.02197265625</td></tr>
-<tr><td>0.53</td><td>0.01098632813</td><td>0.02197265625</td></tr>
-<tr><td>0.52</td><td>0.01098632813</td><td>0.01098632813</td></tr>
-<tr><td>0.5</td><td>0.005493164063</td><td>0.01098632813</td></tr>
-<tr><td>0.48</td><td>0.005493164063</td><td>0.005493164063</td></tr>
-<tr><td>0.47</td><td>0.002746582031</td><td>0.005493164063</td></tr>
-<tr><td>0.45</td><td>0.002746582031</td><td>0.002746582031</td></tr>
-<tr><td>0.43</td><td>0.001373291016</td><td>0.002746582031</td></tr>
-<tr><td>0.42</td><td>0.001373291016</td><td>0.001373291016</td></tr>
-<tr><td>0.4</td><td>0.0006866455078</td><td>0.001373291016</td></tr>
-<tr><td>0.38</td><td>0.0006866455078</td><td>0.0006866455078</td></tr>
-<tr><td>0.37</td><td>0.0003433227539</td><td>0.0006866455078</td></tr>
-<tr><td>0.35</td><td>0.0003433227539</td><td>0.0003433227539</td></tr>
-<tr><td>0.33</td><td>0.000171661377</td><td>0.0003433227539</td></tr>
-<tr><td>0.32</td><td>0.000171661377</td><td>0.000171661377</td></tr>
-<tr><td>0.3</td><td>0.00008583068848</td><td>0.000171661377</td></tr>
-<tr><td>0.28</td><td>0.00008583068848</td><td>0.00008583068848</td></tr>
-<tr><td>0.27</td><td>0.00004291534424</td><td>0.00008583068848</td></tr>
-<tr><td>0.25</td><td>0.00004291534424</td><td>0.00004291534424</td></tr>
-<tr><td>0.23</td><td>0.00002145767212</td><td>0.00004291534424</td></tr>
-<tr><td>0.22</td><td>0.00002145767212</td><td>0.00002145767212</td></tr>
-<tr><td>0.2</td><td>0.00001072883606</td><td>0.00002145767212</td></tr>
-<tr><td>0.18</td><td>0.00001072883606</td><td>0.00001072883606</td></tr>
-<tr><td>0.17</td><td>0.00000536441803</td><td>0.00001072883606</td></tr>
-<tr><td>0.15</td><td>0.00000536441803</td><td>0.00000536441803</td></tr>
-<tr><td>0.13</td><td>0.000002682209015</td><td>0.00000536441803</td></tr>
-<tr><td>0.12</td><td>0.000002682209015</td><td>0.000002682209015</td></tr>
-<tr><td>0.1</td><td>0.000001341104507</td><td>0.000002682209015</td></tr>
-<tr><td>0.08</td><td>0.000001341104507</td><td>0.000001341104507</td></tr>
-<tr><td>0.07</td><td>0.0000006705522537</td><td>0.000001341104507</td></tr>
-<tr><td>0.05</td><td>0.0000006705522537</td><td>0.0000006705522537</td></tr>
-<tr><td>0.03</td><td>0.0000003352761269</td><td>0.0000006705522537</td></tr>
-<tr><td>0.02</td><td>0.0000003352761269</td><td>0.0000003352761269</td></tr>
-<tr><td>0</td><td>0.0000001676380634</td><td>0.0000003352761269</td></tr>
+        <tr><td>1</td><td>0</td><td>180</td><td>360</td></tr>
+        <tr><td>0.98</td><td>1</td><td>180</td><td>180</td></tr>
+        <tr><td>0.97</td><td>2</td><td>90</td><td>180</td></tr>
+        <tr><td>0.95</td><td>3</td><td>90</td><td>90</td></tr>
+        <tr><td>0.93</td><td>4</td><td>45</td><td>90</td></tr>
+        <tr><td>0.92</td><td>5</td><td>45</td><td>45</td></tr>
+        <tr><td>0.9</td><td>6</td><td>22.5</td><td>45</td></tr>
+        <tr><td>0.88</td><td>7</td><td>22.5</td><td>22.5</td></tr>
+        <tr><td>0.87</td><td>8</td><td>11.25</td><td>22.5</td></tr>
+        <tr><td>0.85</td><td>9</td><td>11.25</td><td>11.25</td></tr>
+        <tr><td>0.83</td><td>10</td><td>5.625</td><td>11.25</td></tr>
+        <tr><td>0.82</td><td>11</td><td>5.625</td><td>5.625</td></tr>
+        <tr><td>0.8</td><td>12</td><td>2.8125</td><td>5.625</td></tr>
+        <tr><td>0.78</td><td>13</td><td>2.8125</td><td>2.8125</td></tr>
+        <tr><td>0.77</td><td>14</td><td>1.40625</td><td>2.8125</td></tr>
+        <tr><td>0.75</td><td>15</td><td>1.40625</td><td>1.40625</td></tr>
+        <tr><td>0.73</td><td>16</td><td>0.703125</td><td>1.40625</td></tr>
+        <tr><td>0.72</td><td>17</td><td>0.703125</td><td>0.703125</td></tr>
+        <tr><td>0.7</td><td>18</td><td>0.3515625</td><td>0.703125</td></tr>
+        <tr><td>0.68</td><td>19</td><td>0.3515625</td><td>0.3515625</td></tr>
+        <tr><td>0.67</td><td>20</td><td>0.17578125</td><td>0.3515625</td></tr>
+        <tr><td>0.65</td><td>21</td><td>0.17578125</td><td>0.17578125</td></tr>
+        <tr><td>0.63</td><td>22</td><td>0.087890625</td><td>0.17578125</td></tr>
+        <tr><td>0.62</td><td>23</td><td>0.087890625</td><td>0.087890625</td></tr>
+        <tr><td>0.6</td><td>24</td><td>0.0439453125</td><td>0.087890625</td></tr>
+        <tr><td>0.58</td><td>25</td><td>0.0439453125</td><td>0.0439453125</td></tr>
+        <tr><td>0.57</td><td>26</td><td>0.02197265625</td><td>0.0439453125</td></tr>
+        <tr><td>0.55</td><td>27</td><td>0.02197265625</td><td>0.02197265625</td></tr>
+        <tr><td>0.53</td><td>28</td><td>0.010986328125</td><td>0.02197265625</td></tr>
+        <tr><td>0.52</td><td>29</td><td>0.010986328125</td><td>0.010986328125</td></tr>
+        <tr><td>0.5</td><td>30</td><td>0.0054931640625</td><td>0.010986328125</td></tr>
+        <tr><td>0.48</td><td>31</td><td>0.0054931640625</td><td>0.0054931640625</td></tr>
+        <tr><td>0.47</td><td>32</td><td>0.00274658203125</td><td>0.0054931640625</td></tr>
+        <tr><td>0.45</td><td>33</td><td>0.00274658203125</td><td>0.00274658203125</td></tr>
+        <tr><td>0.43</td><td>34</td><td>0.001373291015625</td><td>0.00274658203125</td></tr>
+        <tr><td>0.42</td><td>35</td><td>0.001373291015625</td><td>0.001373291015625</td></tr>
+        <tr><td>0.4</td><td>36</td><td>0.0006866455078125</td><td>0.001373291015625</td></tr>
+        <tr><td>0.38</td><td>37</td><td>0.0006866455078125</td><td>0.0006866455078125</td></tr>
+        <tr><td>0.37</td><td>38</td><td>0.0003433227539062</td><td>0.0006866455078125</td></tr>
+        <tr><td>0.35</td><td>39</td><td>0.0003433227539062</td><td>0.0003433227539062</td></tr>
+        <tr><td>0.33</td><td>40</td><td>0.0001716613769531</td><td>0.0003433227539062</td></tr>
+        <tr><td>0.32</td><td>41</td><td>0.0001716613769531</td><td>0.0001716613769531</td></tr>
+        <tr><td>0.3</td><td>42</td><td>0.0000858306884766</td><td>0.0001716613769531</td></tr>
+        <tr><td>0.28</td><td>43</td><td>0.0000858306884766</td><td>0.0000858306884766</td></tr>
+        <tr><td>0.27</td><td>44</td><td>0.0000429153442383</td><td>0.0000858306884766</td></tr>
+        <tr><td>0.25</td><td>45</td><td>0.0000429153442383</td><td>0.0000429153442383</td></tr>
+        <tr><td>0.23</td><td>46</td><td>0.0000214576721191</td><td>0.0000429153442383</td></tr>
+        <tr><td>0.22</td><td>47</td><td>0.0000214576721191</td><td>0.0000214576721191</td></tr>
+        <tr><td>0.2</td><td>48</td><td>0.0000107288360596</td><td>0.0000214576721191</td></tr>
+        <tr><td>0.18</td><td>49</td><td>0.0000107288360596</td><td>0.0000107288360596</td></tr>
+        <tr><td>0.17</td><td>50</td><td>0.0000053644180298</td><td>0.0000107288360596</td></tr>
+        <tr><td>0.15</td><td>51</td><td>0.0000053644180298</td><td>0.0000053644180298</td></tr>
+        <tr><td>0.13</td><td>52</td><td>0.0000026822090149</td><td>0.0000053644180298</td></tr>
+        <tr><td>0.12</td><td>53</td><td>0.0000026822090149</td><td>0.0000026822090149</td></tr>
+        <tr><td>0.1</td><td>54</td><td>0.0000013411045074</td><td>0.0000026822090149</td></tr>
+        <tr><td>0.08</td><td>55</td><td>0.0000013411045074</td><td>0.0000013411045074</td></tr>
+        <tr><td>0.07</td><td>56</td><td>0.0000006705522537</td><td>0.0000013411045074</td></tr>
+        <tr><td>0.05</td><td>57</td><td>0.0000006705522537</td><td>0.0000006705522537</td></tr>
+        <tr><td>0.03</td><td>58</td><td>0.0000003352761269</td><td>0.0000006705522537</td></tr>
+        <tr><td>0.02</td><td>59</td><td>0.0000003352761269</td><td>0.0000003352761269</td></tr>
+        <tr><td>0.0</td><td>60</td><td>0.0000001676380634</td><td>0.0000003352761269</td></tr>
         </tbody>
 </table>
 

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/Cluster.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/Cluster.java
@@ -1,10 +1,8 @@
 package nl.trifork.elasticsearch.facet.geohash;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.elasticsearch.common.Preconditions;
-import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/ClusterBuilder.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/ClusterBuilder.java
@@ -15,8 +15,8 @@ public class ClusterBuilder {
 	private final int geohashBits;
 	private final Map<Long, Cluster> clusters = Maps.newHashMap();
 
-	public ClusterBuilder(double factor) {
-        this.geohashBits = BinaryGeoHashUtils.MAX_PREFIX_LENGTH - (int) Math.round(factor * BinaryGeoHashUtils.MAX_PREFIX_LENGTH);
+	public ClusterBuilder(int precisionBits) {
+        this.geohashBits = precisionBits;
 	}
 
 	public ClusterBuilder add(TypeAndId typeAndId, GeoPoint point) {

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/ClusterBuilder.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/ClusterBuilder.java
@@ -2,7 +2,6 @@ package nl.trifork.elasticsearch.facet.geohash;
 
 import java.util.Map;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.collect.Maps;
 import org.elasticsearch.common.geo.GeoPoint;

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeoFacetBuilder.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeoFacetBuilder.java
@@ -1,19 +1,10 @@
 package nl.trifork.elasticsearch.facet.geohash;
 
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.client.Client;
-import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import java.io.IOException;
+
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilderException;
 import org.elasticsearch.search.facet.FacetBuilder;
-import org.elasticsearch.search.facet.terms.TermsFacet;
-
-import java.io.IOException;
-import java.util.Map;
 
 public class GeoFacetBuilder extends FacetBuilder {
     private String fieldName;

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeoFacetBuilder.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeoFacetBuilder.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 public class GeoFacetBuilder extends FacetBuilder {
     private String fieldName;
-    private double factor;
+    private int precisionBits;
     private boolean showGeohashCell;
     private boolean showDocId;
 
@@ -48,8 +48,8 @@ public class GeoFacetBuilder extends FacetBuilder {
         return this;
     }
 
-    public GeoFacetBuilder factor(double factor) {
-        this.factor = factor;
+    public GeoFacetBuilder precisionBits(int precisionBits) {
+        this.precisionBits = precisionBits;
         return this;
     }
 
@@ -62,7 +62,7 @@ public class GeoFacetBuilder extends FacetBuilder {
 
         builder.startObject("geohash");
         builder.field("field", fieldName);
-        builder.field("factor", factor);
+        builder.field("precision_bits", precisionBits);
         builder.field("show_geohash_cell", showGeohashCell);
         builder.field("show_doc_id", showDocId);
 

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeohashFacetExecutor.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/GeohashFacetExecutor.java
@@ -18,19 +18,19 @@ public class GeohashFacetExecutor extends FacetExecutor {
 
 	private final IndexGeoPointFieldData<?> indexFieldData;
 	private final IndexFieldData<?> idIndexFieldData;
-	private final double factor;
+	private final int precisionBits;
     private final boolean showGeohashCell;
     private final boolean showDocumentId;
 	private final ClusterBuilder builder;
 	
 	public GeohashFacetExecutor(IndexGeoPointFieldData<?> indexFieldData, IndexFieldData<?> idIndexFieldData, 
-			                    double factor, boolean showGeohashCell, boolean showDocumentId) {
+			                    int precisionBits, boolean showGeohashCell, boolean showDocumentId) {
 		this.indexFieldData = indexFieldData;
 		this.idIndexFieldData = idIndexFieldData;
-		this.factor = factor;
+		this.precisionBits = precisionBits;
         this.showGeohashCell = showGeohashCell;
         this.showDocumentId = showDocumentId;
-		this.builder = new ClusterBuilder(factor);
+		this.builder = new ClusterBuilder(precisionBits);
 	}
 
 	@Override
@@ -40,7 +40,7 @@ public class GeohashFacetExecutor extends FacetExecutor {
 
 	@Override
 	public InternalFacet buildFacet(String facetName) {
-		return new InternalGeohashFacet(facetName, factor, showGeohashCell, showDocumentId, builder.build());
+		return new InternalGeohashFacet(facetName, precisionBits, showGeohashCell, showDocumentId, builder.build());
 	}
 
 	private class Collector extends FacetExecutor.Collector {

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
@@ -33,7 +33,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 		Streams.registerStream(STREAM, STREAM_TYPE);
 	}
 
-	private double factor;
+	private int precisionBits;
     private boolean showGeohashCell;
     private boolean showDocuments;
 	private List<Cluster> entries;
@@ -42,9 +42,9 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 
 	}
 
-	public InternalGeohashFacet(String name, double factor, boolean showGeohashCell, boolean showDocuments, List<Cluster> entries) {
+	public InternalGeohashFacet(String name, int precisionBits, boolean showGeohashCell, boolean showDocuments, List<Cluster> entries) {
 		super(name);
-		this.factor = factor;
+		this.precisionBits = precisionBits;
         this.showGeohashCell = showGeohashCell;
         this.showDocuments = showDocuments;
 		this.entries = entries;
@@ -74,7 +74,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 	public Facet reduce(ReduceContext context) {
 		ClusterReducer reducer = new ClusterReducer();
 		List<Cluster> reduced = reducer.reduce(flatMap(context.facets()));
-		return new InternalGeohashFacet(getName(), factor, showGeohashCell, showDocuments, reduced);
+		return new InternalGeohashFacet(getName(), precisionBits, showGeohashCell, showDocuments, reduced);
 	}
 
 	private List<Cluster> flatMap(Iterable<Facet> facets) {
@@ -94,7 +94,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 	@Override
 	public void readFrom(StreamInput in) throws IOException {
 		super.readFrom(in);
-		factor = in.readDouble();
+		precisionBits = in.readInt();
         showGeohashCell = in .readBoolean();
         showDocuments = in.readBoolean();
         int entriesCount = in.readVInt();
@@ -107,7 +107,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 	@Override
 	public void writeTo(StreamOutput out) throws IOException {
 		super.writeTo(out);
-		out.writeDouble(factor);
+		out.writeInt(precisionBits);
         out.writeBoolean(showGeohashCell);
         out.writeBoolean(showDocuments);
 		out.writeVInt(entries.size());
@@ -121,6 +121,8 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject(getName());
         builder.field(Fields._TYPE, TYPE);
+        builder.field(Fields.PRECISION_BITS, precisionBits);
+        double factor = (1.0 * BinaryGeoHashUtils.MAX_PREFIX_LENGTH - precisionBits) / BinaryGeoHashUtils.MAX_PREFIX_LENGTH;
         builder.field(Fields.FACTOR, factor);
         builder.startArray(Fields.CLUSTERS);
         for (Cluster entry : entries) {
@@ -131,8 +133,8 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
         return builder;
     }
 
-    public double factor() {
-        return factor;
+    public double precisionBits() {
+        return precisionBits;
     }
 
     public boolean showGeohashCell() {
@@ -146,6 +148,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 	private interface Fields {
 
 		final XContentBuilderString _TYPE = new XContentBuilderString("_type");
+		final XContentBuilderString PRECISION_BITS = new XContentBuilderString("precision_bits");
 		final XContentBuilderString FACTOR = new XContentBuilderString("factor");
 		final XContentBuilderString CLUSTERS = new XContentBuilderString("clusters");
 		final XContentBuilderString TOTAL = new XContentBuilderString("total");

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
@@ -8,7 +8,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.HashedBytesArray;
 import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.collect.Lists;
-import org.elasticsearch.common.geo.GeoHashUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
+++ b/src/main/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacet.java
@@ -124,6 +124,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
         builder.field(Fields.PRECISION_BITS, precisionBits);
         double factor = (1.0 * BinaryGeoHashUtils.MAX_PREFIX_LENGTH - precisionBits) / BinaryGeoHashUtils.MAX_PREFIX_LENGTH;
         builder.field(Fields.FACTOR, factor);
+        builder.field(Fields.CLUSTERS_TOTAL, entries.size());
         builder.startArray(Fields.CLUSTERS);
         for (Cluster entry : entries) {
             toXContent(entry, builder);
@@ -150,6 +151,7 @@ public class InternalGeohashFacet extends InternalFacet implements GeohashFacet 
 		final XContentBuilderString _TYPE = new XContentBuilderString("_type");
 		final XContentBuilderString PRECISION_BITS = new XContentBuilderString("precision_bits");
 		final XContentBuilderString FACTOR = new XContentBuilderString("factor");
+		final XContentBuilderString CLUSTERS_TOTAL = new XContentBuilderString("clusters_total");
 		final XContentBuilderString CLUSTERS = new XContentBuilderString("clusters");
 		final XContentBuilderString TOTAL = new XContentBuilderString("total");
 		final XContentBuilderString CENTER = new XContentBuilderString("center");

--- a/src/test/java/nl/trifork/elasticsearch/clustering/grid/ClusterTests.java
+++ b/src/test/java/nl/trifork/elasticsearch/clustering/grid/ClusterTests.java
@@ -1,7 +1,5 @@
 package nl.trifork.elasticsearch.clustering.grid;
 
-import static nl.trifork.elasticsearch.clustering.grid.test.GeoPointMatchers.closeTo;
-import static nl.trifork.elasticsearch.clustering.grid.test.Places.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -9,9 +7,8 @@ import java.io.IOException;
 import java.util.Random;
 
 import nl.trifork.elasticsearch.facet.geohash.BinaryGeoHashUtils;
-import nl.trifork.elasticsearch.facet.geohash.BoundingBox;
 import nl.trifork.elasticsearch.facet.geohash.Cluster;
-import nl.trifork.elasticsearch.facet.geohash.GeoPoints;
+
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;

--- a/src/test/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacetTests.java
+++ b/src/test/java/nl/trifork/elasticsearch/facet/geohash/InternalGeohashFacetTests.java
@@ -18,7 +18,7 @@ public class InternalGeohashFacetTests {
 
         InternalGeohashFacet facet = new InternalGeohashFacet(
                 "name",
-                0.5,
+                30,
                 true,
                 false,
                 Arrays.asList(new Cluster(Places.DENVER,
@@ -34,7 +34,7 @@ public class InternalGeohashFacetTests {
         InternalGeohashFacet deserialized = new InternalGeohashFacet();
         deserialized.readFrom(new BytesStreamInput(byteArrayOutputStream.toByteArray(), false));
 
-        assertThat(deserialized.factor(), is(facet.factor()));
+        assertThat(deserialized.precisionBits(), is(facet.precisionBits()));
         assertThat(deserialized.showGeohashCell(), is(facet.showGeohashCell()));
         assertThat(deserialized.getEntries().size(), is(1));
         assertThat(deserialized.getEntries().get(0).center(), is(Places.DENVER));


### PR DESCRIPTION
It's some how confusing to talk about binary geohashs and use a double as factor. This patch replaces the factor parameter by a precision bits parameter (using the factor parameter is also possible).

Additionally this adds a cluster_total as output and fix some unused imports.
